### PR TITLE
refactor: correct theme and translation key naming inconsistencies

### DIFF
--- a/src/components/InvitationForm.tsx
+++ b/src/components/InvitationForm.tsx
@@ -575,8 +575,8 @@ export const InvitationForm = () => {
                                 <SelectItem value="friends">Best Friends</SelectItem>
                                  <SelectItem value="work">Work Colleagues</SelectItem>
                                 <SelectItem value="neighbors">Neighbors</SelectItem>
-                                <SelectItem value="bridesbrowtherfriends">Bride's Brother Friends</SelectItem>
-                                <SelectItem value="bridebrotherworkcolleague">Bride's Brother Work Colleagues</SelectItem>
+                                <SelectItem value="bridesbrotherfriends">Bride's Brother Friends</SelectItem>
++                               <SelectItem value="bridesbrotherworkcolleagues">Bride's Brother Work Colleagues</SelectItem> 
                                  <SelectItem value="elegant">Elegant</SelectItem>
                                 <SelectItem value="modern">Modern</SelectItem>
                                 <SelectItem value="rustic">Rustic</SelectItem>

--- a/src/components/PDFPreview.tsx
+++ b/src/components/PDFPreview.tsx
@@ -78,10 +78,10 @@ const getThemeMessage = (theme: string, language: string = 'english') => {
             return getTranslation("workTheme", language);
          case "neighbors":
             return getTranslation("neighborsTheme", language);
-         case "bridesbrowtherfriends":
-            return getTranslation("bridesbrothersFriendTheme", language);
-         case "bridebrotherworkcolleague":
-            return getTranslation("bridebrotherworkcolleagueTheme", language);
+         case "bridesbrotherfriends":
+            return getTranslation("bridesbrotherFriendTheme", language);
+         case "bridesbrotherworkcolleagues":
+            return getTranslation("bridesbrotherworkcolleaguesTheme", language);
         default:
             return getTranslation("defaultTheme", language);
     }

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -266,8 +266,8 @@ export const translateUserInput = (text: string, language: string = 'english'): 
                 const dayOfWeek = date.toLocaleDateString('en-US', { weekday: 'long' }).toLowerCase();
                 const month = date.toLocaleDateString('en-US', { month: 'long' }).toLowerCase();
 
-                let tamilDay = translations[dayOfWeek]?.[language] || dayOfWeek; // Use helper safely
-                let tamilMonth = translations[month]?.[language] || month;
+                const tamilDay = translations[dayOfWeek]?.[language] || dayOfWeek; // Use helper safely
+                const tamilMonth = translations[month]?.[language] || month;
 
                 // Format in Tamil style (Adjust format string as needed)
                 // Example: சனிக்கிழமை, ஏப்ரல் 26, 2025
@@ -324,20 +324,5 @@ export const translateUserInput = (text: string, language: string = 'english'): 
             }
         }
     });
-
-
-    // It's generally better *not* to try and translate the entire text if it wasn't a date
-    // and wasn't a direct match earlier. The simple word replacer is too basic for full sentences.
-    // However, if you *must* check for full phrase matches again (less recommended):
-    /*
-    Object.keys(translations).forEach(key => {
-        if (translations[key].english.toLowerCase() === lowerText) {
-             // Be careful, this might overwrite partial replacements done above
-             translatedText = translations[key][language] || text;
-        }
-    });
-    */
-
-
     return translatedText;
 };


### PR DESCRIPTION
Fix inconsistent naming of theme and translation keys in PDFPreview and InvitationForm components. Also, simplify translations.ts by removing redundant comments and improving variable declarations.